### PR TITLE
chore: update coverage

### DIFF
--- a/resources/coverage/1.1008100.0.json
+++ b/resources/coverage/1.1008100.0.json
@@ -10,9 +10,9 @@
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "post",
       "tested": true,
@@ -20,16 +20,20 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "create a GatewayClass"
+      "description": "create a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
@@ -37,16 +41,239 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
       "conf_tested": true,
-      "description": "create a Gateway"
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
       ],
       "action": "post",
       "tested": true,
@@ -54,14 +281,761 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
       "conf_tested": true,
-      "description": "create a HTTPRoute"
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -71,14 +1045,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GatewayClass"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -88,14 +1064,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGateway",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "delete collection of Gateway"
+      "description": "delete collection of Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -105,16 +1083,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedHTTPRoute",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "delete collection of HTTPRoute"
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "delete",
       "tested": true,
@@ -122,16 +1102,20 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "delete a GatewayClass"
+      "description": "delete a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
       ],
       "action": "delete",
       "tested": true,
@@ -139,16 +1123,239 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
       "conf_tested": true,
-      "description": "delete a Gateway"
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
       ],
       "action": "delete",
       "tested": true,
@@ -156,14 +1363,761 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
       "conf_tested": true,
-      "description": "delete a HTTPRoute"
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -173,14 +2127,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -190,31 +2146,164 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        null
+        "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -224,16 +2313,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
       ],
       "action": "list",
       "tested": true,
@@ -241,14 +2332,19 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
       "conf_tested": true,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -258,16 +2354,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -275,14 +2373,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified GatewayClass"
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -292,16 +2394,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -309,14 +2413,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
       "conf_tested": true,
-      "description": "partially update the specified Gateway"
+      "description": "partially update the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -326,16 +2434,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
       ],
       "action": "patch",
       "tested": true,
@@ -343,14 +2453,19 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified HTTPRoute"
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -360,31 +2475,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -394,14 +2494,56 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "read the specified GatewayClass"
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -411,16 +2553,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
       ],
       "action": "get",
       "tested": true,
@@ -428,14 +2572,914 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
       "conf_tested": true,
-      "description": "read the specified Gateway"
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -445,16 +3489,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified Gateway"
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
       ],
       "action": "get",
       "tested": true,
@@ -462,14 +3508,761 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
       "conf_tested": true,
-      "description": "read the specified HTTPRoute"
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -479,14 +4272,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -496,14 +4291,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GatewayClass"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
@@ -513,14 +4310,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -530,14 +4329,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified Gateway"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
@@ -547,14 +4348,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified Gateway"
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -564,14 +4367,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
@@ -581,694 +4386,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "post",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "create a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
-      "conf_tested": null,
-      "description": "delete collection of GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
-      "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "delete a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "delete a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "partially update the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "partially update the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "partially update the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "read status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "read the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "replace the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "replace the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1278,14 +4405,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendTLSPolicy"
+      "description": "create a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1295,14 +4424,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1312,14 +4443,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a ReferenceGrant"
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1329,16 +4462,18 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TCPRoute"
+      "description": "create a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
       ],
       "action": "post",
       "tested": true,
@@ -1346,14 +4481,42 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
       "conf_tested": true,
-      "description": "create a TLSRoute"
+      "description": "create a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1363,14 +4526,301 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create an UDPRoute"
+      "description": "create an UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -1380,31 +4830,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendTLSPolicy",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "delete collection of BackendTLSPolicy"
+      "description": "delete collection of BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "deletecollection",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedGRPCRoute",
-      "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1414,48 +4868,54 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "deletecollection",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTCPRoute",
-      "conf_tested": null,
-      "description": "delete collection of TCPRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "delete collection of TCPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "deletecollection",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTLSRoute",
-      "conf_tested": null,
-      "description": "delete collection of TLSRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "delete collection of TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -1465,14 +4925,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedUDPRoute",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "delete collection of UDPRoute"
+      "description": "delete collection of UDPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1482,14 +4944,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendTLSPolicy"
+      "description": "delete a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1499,14 +4963,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1516,14 +4982,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a ReferenceGrant"
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1533,16 +5001,18 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TCPRoute"
+      "description": "delete a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
       ],
       "action": "delete",
       "tested": true,
@@ -1550,14 +5020,42 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
       "conf_tested": true,
-      "description": "delete a TLSRoute"
+      "description": "delete a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1567,14 +5065,377 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete an UDPRoute"
+      "description": "delete an UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
+      ],
+      "action": "deletecollection",
+      "tested": false,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1584,31 +5445,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2BackendTLSPolicyForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -1618,31 +5483,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedGRPCRoute",
-      "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1652,48 +5521,54 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTCPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
       ],
@@ -1703,14 +5578,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1720,14 +5597,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2ReferenceGrantForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1737,31 +5616,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1771,14 +5654,149 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:namespace-controller"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1788,14 +5806,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendTLSPolicy"
+      "description": "partially update the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1805,14 +5825,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendTLSPolicy"
+      "description": "partially update status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1822,14 +5844,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1839,14 +5863,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GRPCRoute"
+      "description": "partially update status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1856,14 +5882,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1873,14 +5901,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TCPRoute"
+      "description": "partially update the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1890,14 +5920,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TCPRoute"
+      "description": "partially update status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1907,14 +5939,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TLSRoute"
+      "description": "partially update the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1924,14 +5958,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TLSRoute"
+      "description": "partially update status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1941,14 +5977,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified UDPRoute"
+      "description": "partially update the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1958,14 +5996,149 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified UDPRoute"
+      "description": "partially update status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "patch",
+      "tested": false,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1975,14 +6148,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendTLSPolicy"
+      "description": "read the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1992,14 +6167,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendTLSPolicy"
+      "description": "read status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2009,14 +6186,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2026,14 +6205,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GRPCRoute"
+      "description": "read status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2043,14 +6224,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2060,14 +6243,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TCPRoute"
+      "description": "read the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2077,16 +6262,18 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TCPRoute"
+      "description": "read status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
       ],
       "action": "get",
       "tested": true,
@@ -2094,14 +6281,42 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
       "conf_tested": true,
-      "description": "read the specified TLSRoute"
+      "description": "read the specified TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2111,14 +6326,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TLSRoute"
+      "description": "read status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2128,14 +6345,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified UDPRoute"
+      "description": "read the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2145,14 +6364,358 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified UDPRoute"
+      "description": "read status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "get",
+      "tested": false,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2162,14 +6725,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendTLSPolicy"
+      "description": "replace the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2179,14 +6744,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendTLSPolicy"
+      "description": "replace status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2196,14 +6763,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2213,14 +6782,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified GRPCRoute"
+      "description": "replace status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2230,14 +6801,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2247,14 +6820,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TCPRoute"
+      "description": "replace the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2264,14 +6839,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TCPRoute"
+      "description": "replace status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2281,14 +6858,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TLSRoute"
+      "description": "replace the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "cilium-operator-generic/1.15.4 9b3f9a8c 2024-04-11T17:25:42-04:00 go version go1.21.9 linux/amd64"
       ],
@@ -2298,14 +6877,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified TLSRoute"
+      "description": "replace status of the specified TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2315,14 +6896,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified UDPRoute"
+      "description": "replace the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2332,11 +6915,146 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified UDPRoute"
+      "description": "replace status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     }
   ],
-  "release_date": "2024-07-08T03:26:13",
+  "release_date": "2024-07-15T23:36:57",
   "total endpoints": 135,
   "tested endpoints": 25
 }

--- a/resources/coverage/1.1008110.0.json
+++ b/resources/coverage/1.1008110.0.json
@@ -10,41 +10,45 @@
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "create a GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -54,31 +58,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -88,14 +96,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GatewayClass"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -105,14 +115,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of Gateway"
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -122,14 +134,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -139,48 +153,54 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "delete a GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -190,31 +210,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -224,31 +248,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        null
+        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -258,14 +286,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -275,31 +305,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "list",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "list objects of kind Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -309,14 +343,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -326,31 +362,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "partially update the specified GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -360,31 +400,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "partially update the specified Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -394,14 +438,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -411,14 +457,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -428,31 +476,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GRPCRoute"
+      "description": "partially update status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "partially update the specified HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -462,14 +514,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -479,31 +533,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -513,31 +552,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "get",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -547,14 +590,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified Gateway"
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -564,14 +609,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -581,31 +628,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GRPCRoute"
+      "description": "read status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "get",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -615,14 +666,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -632,14 +685,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GatewayClass"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
       ],
@@ -649,14 +704,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -666,31 +723,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified Gateway"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
+        null
       ],
       "action": "put",
-      "tested": false,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGatewayStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -700,14 +761,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -717,14 +780,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified GRPCRoute"
+      "description": "replace status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -734,711 +799,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
+        null
       ],
       "action": "put",
-      "tested": false,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "post",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "create a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
-      "conf_tested": null,
-      "description": "delete collection of GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
-      "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "delete a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "delete a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "partially update the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "partially update the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "partially update the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "read status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "read the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "replace the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "replace the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1008110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1448,14 +837,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendLBPolicy"
+      "description": "create a BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1465,14 +856,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1482,14 +875,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a ReferenceGrant"
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1499,31 +894,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TCPRoute"
+      "description": "create a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": true,
-      "description": "create a TLSRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1533,14 +932,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create an UDPRoute"
+      "description": "create an UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1550,14 +951,92 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendTLSPolicy"
+      "description": "create a BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1567,14 +1046,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendLBPolicy"
+      "description": "delete collection of BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1584,14 +1065,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1601,14 +1084,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1618,14 +1103,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TCPRoute"
+      "description": "delete collection of TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1635,14 +1122,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TLSRoute"
+      "description": "delete collection of TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1652,14 +1141,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of UDPRoute"
+      "description": "delete collection of UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1669,14 +1160,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendLBPolicy"
+      "description": "delete a BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1686,14 +1179,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1703,14 +1198,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a ReferenceGrant"
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1720,31 +1217,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TCPRoute"
+      "description": "delete a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": true,
-      "description": "delete a TLSRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1754,14 +1255,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete an UDPRoute"
+      "description": "delete an UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1771,14 +1274,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha3CollectionNamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendTLSPolicy"
+      "description": "delete collection of BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1788,14 +1293,168 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendTLSPolicy"
+      "description": "delete a BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1805,14 +1464,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2BackendLBPolicyForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1822,14 +1483,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1839,14 +1502,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1856,14 +1521,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1873,14 +1540,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1890,14 +1559,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1907,14 +1578,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1924,14 +1597,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1941,14 +1616,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2ReferenceGrantForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1958,14 +1635,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1975,14 +1654,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1992,14 +1673,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2009,14 +1692,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha3BackendTLSPolicyForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2026,14 +1711,149 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2043,14 +1863,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendLBPolicy"
+      "description": "partially update the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2060,14 +1882,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendLBPolicy"
+      "description": "partially update status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2077,14 +1901,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2094,14 +1920,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2111,14 +1939,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TCPRoute"
+      "description": "partially update the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2128,14 +1958,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TCPRoute"
+      "description": "partially update status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2145,14 +1977,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TLSRoute"
+      "description": "partially update the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2162,14 +1996,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TLSRoute"
+      "description": "partially update status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2179,14 +2015,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified UDPRoute"
+      "description": "partially update the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2196,14 +2034,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified UDPRoute"
+      "description": "partially update status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2213,14 +2053,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendTLSPolicy"
+      "description": "partially update the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2230,14 +2072,149 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendTLSPolicy"
+      "description": "partially update status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "patch",
+      "tested": false,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2247,14 +2224,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendLBPolicy"
+      "description": "read the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2264,14 +2243,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendLBPolicy"
+      "description": "read status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2281,14 +2262,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2298,14 +2281,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2315,14 +2300,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TCPRoute"
+      "description": "read the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2332,31 +2319,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TCPRoute"
+      "description": "read status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "gateway-api.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        null
       ],
       "action": "get",
-      "tested": true,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": true,
-      "description": "read the specified TLSRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2366,14 +2357,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TLSRoute"
+      "description": "read status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2383,14 +2376,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified UDPRoute"
+      "description": "read the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2400,14 +2395,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified UDPRoute"
+      "description": "read status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2417,14 +2414,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendTLSPolicy"
+      "description": "read the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2434,14 +2433,149 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendTLSPolicy"
+      "description": "read status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "get",
+      "tested": false,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2451,14 +2585,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendLBPolicy"
+      "description": "replace the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2468,14 +2604,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendLBPolicy"
+      "description": "replace status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2485,14 +2623,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2502,14 +2642,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2519,14 +2661,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TCPRoute"
+      "description": "replace the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2536,14 +2680,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TCPRoute"
+      "description": "replace status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2553,31 +2699,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TLSRoute"
+      "description": "replace the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "cilium-operator-generic/1.15.6 a09e05e6 2024-06-08T21:31:01+00:00 go version go1.21.11 linux/amd64"
+        null
       ],
       "action": "put",
-      "tested": false,
+      "tested": null,
       "release": "1.1008110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified TLSRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2587,14 +2737,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified UDPRoute"
+      "description": "replace the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2604,14 +2756,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified UDPRoute"
+      "description": "replace status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2621,14 +2775,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendTLSPolicy"
+      "description": "replace the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2638,11 +2794,146 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendTLSPolicy"
+      "description": "replace status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1008110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     }
   ],
-  "release_date": "2024-07-08T03:32:02",
+  "release_date": "2024-07-15T23:43:07",
   "total endpoints": 154,
-  "tested endpoints": 25
+  "tested endpoints": 0
 }

--- a/resources/coverage/1.1009100.0.json
+++ b/resources/coverage/1.1009100.0.json
@@ -10,26 +10,9 @@
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "kubectl/v1.30.1 (linux/amd64) kubernetes/6911225"
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
       "action": "post",
       "tested": false,
@@ -37,16 +20,39 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "create a GatewayClass"
+      "description": "create a GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
+      "conf_tested": true,
+      "description": "create a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
@@ -54,16 +60,128 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
       "conf_tested": true,
-      "description": "create a Gateway"
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
@@ -71,14 +189,392 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
       "conf_tested": true,
-      "description": "create a HTTPRoute"
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -88,14 +584,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GatewayClass"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -105,14 +603,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of Gateway"
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -122,16 +622,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "delete",
       "tested": true,
@@ -139,16 +641,20 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "delete a GatewayClass"
+      "description": "delete a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
       ],
       "action": "delete",
       "tested": true,
@@ -156,16 +662,128 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
       "conf_tested": true,
-      "description": "delete a Gateway"
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
       ],
       "action": "delete",
       "tested": true,
@@ -173,14 +791,370 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
       "conf_tested": true,
-      "description": "delete a HTTPRoute"
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -190,14 +1164,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -207,16 +1183,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "kubectl/v1.30.1 (linux/amd64) kubernetes/6911225"
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
       "action": "list",
       "tested": false,
@@ -224,16 +1202,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "kubectl/v1.30.1 (linux/amd64) kubernetes/6911225"
+        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
       "action": "list",
       "tested": false,
@@ -241,14 +1221,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -258,31 +1240,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1009100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
+      "tests": [
+        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -292,33 +1278,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1009100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
       ],
       "action": "list",
       "tested": true,
@@ -326,14 +1297,103 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteObservedGenerationBump",
       "conf_tested": true,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -343,16 +1403,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -360,14 +1422,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified GatewayClass"
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -377,16 +1443,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -394,14 +1462,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
       "conf_tested": true,
-      "description": "partially update the specified Gateway"
+      "description": "partially update the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -411,16 +1483,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
       ],
       "action": "patch",
       "tested": true,
@@ -428,14 +1502,19 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified HTTPRoute"
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -445,33 +1524,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "kubectl/v1.30.1 (linux/amd64) kubernetes/6911225"
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
       "action": "get",
       "tested": false,
@@ -479,14 +1543,56 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "read the specified GatewayClass"
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayClassObservedGenerationBump::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -496,16 +1602,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
       ],
       "action": "get",
       "tested": true,
@@ -513,14 +1621,412 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
       "conf_tested": true,
-      "description": "read the specified Gateway"
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -530,16 +2036,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified Gateway"
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
+        "gateway-api-conformance.test::v1.0.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
       ],
       "action": "get",
       "tested": true,
@@ -547,14 +2055,392 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
       "conf_tested": true,
-      "description": "read the specified HTTPRoute"
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -564,14 +2450,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -581,14 +2469,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GatewayClass"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -598,14 +2488,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -615,14 +2507,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified Gateway"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -632,14 +2526,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified Gateway"
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -649,14 +2545,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -666,711 +2564,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "post",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "post",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "create a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
-      "conf_tested": null,
-      "description": "delete collection of GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
-      "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "delete a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "partially update the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "partially update the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "partially update the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "read status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "conformance.test/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "replace the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "replace the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1009100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1380,14 +2583,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendTLSPolicy"
+      "description": "create a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1397,14 +2602,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1414,14 +2621,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a ReferenceGrant"
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1431,14 +2640,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TCPRoute"
+      "description": "create a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1448,14 +2659,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TLSRoute"
+      "description": "create a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1465,14 +2678,117 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create an UDPRoute"
+      "description": "create an UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1482,14 +2798,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendTLSPolicy"
+      "description": "delete collection of BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1499,14 +2817,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1516,14 +2836,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1533,14 +2855,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TCPRoute"
+      "description": "delete collection of TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1550,14 +2874,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TLSRoute"
+      "description": "delete collection of TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1567,14 +2893,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of UDPRoute"
+      "description": "delete collection of UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1584,14 +2912,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendTLSPolicy"
+      "description": "delete a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1601,14 +2931,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1618,14 +2950,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a ReferenceGrant"
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1635,14 +2969,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TCPRoute"
+      "description": "delete a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1652,14 +2988,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TLSRoute"
+      "description": "delete a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1669,14 +3007,174 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete an UDPRoute"
+      "description": "delete an UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -1686,14 +3184,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2BackendTLSPolicyForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -1703,14 +3203,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2BackendTLSPolicyForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -1720,14 +3222,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -1737,14 +3241,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1754,14 +3260,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1771,14 +3279,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1788,14 +3298,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1805,14 +3317,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1822,14 +3336,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1839,14 +3355,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1856,31 +3374,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2ReferenceGrantForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1009100.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
-    },
-    {
-      "kind": "TCPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -1890,14 +3393,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": []
     },
     {
-      "kind": "TLSRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
+      "kind": "TCPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
       ],
@@ -1906,15 +3411,17 @@
       "release": "1.1009100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -1924,14 +3431,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1009100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -1941,14 +3469,168 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "contour/v0.0.0 (linux/amd64) kubernetes/$Format"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1958,14 +3640,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendTLSPolicy"
+      "description": "partially update the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1975,14 +3659,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendTLSPolicy"
+      "description": "partially update status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1992,14 +3678,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2009,14 +3697,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GRPCRoute"
+      "description": "partially update status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2026,14 +3716,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2043,14 +3735,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TCPRoute"
+      "description": "partially update the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2060,14 +3754,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TCPRoute"
+      "description": "partially update status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2077,14 +3773,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TLSRoute"
+      "description": "partially update the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2094,14 +3792,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TLSRoute"
+      "description": "partially update status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2111,14 +3811,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified UDPRoute"
+      "description": "partially update the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2128,14 +3830,149 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified UDPRoute"
+      "description": "partially update status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2145,14 +3982,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendTLSPolicy"
+      "description": "read the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2162,14 +4001,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendTLSPolicy"
+      "description": "read status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2179,14 +4020,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2196,14 +4039,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GRPCRoute"
+      "description": "read status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2213,14 +4058,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2230,14 +4077,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TCPRoute"
+      "description": "read the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2247,14 +4096,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TCPRoute"
+      "description": "read status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2264,14 +4115,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TLSRoute"
+      "description": "read the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2281,14 +4134,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TLSRoute"
+      "description": "read status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2298,14 +4153,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified UDPRoute"
+      "description": "read the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2315,14 +4172,174 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified UDPRoute"
+      "description": "read status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2332,14 +4349,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendTLSPolicy"
+      "description": "replace the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2349,14 +4368,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendTLSPolicy"
+      "description": "replace status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2366,14 +4387,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2383,14 +4406,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified GRPCRoute"
+      "description": "replace status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2400,14 +4425,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2417,14 +4444,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TCPRoute"
+      "description": "replace the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2434,14 +4463,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TCPRoute"
+      "description": "replace status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2451,14 +4482,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TLSRoute"
+      "description": "replace the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2468,14 +4501,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TLSRoute"
+      "description": "replace status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2485,14 +4520,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified UDPRoute"
+      "description": "replace the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2502,11 +4539,146 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified UDPRoute"
+      "description": "replace status of the specified UDPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1009100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     }
   ],
-  "release_date": "2024-07-07T21:47:29",
+  "release_date": "2024-07-15T23:46:35",
   "total endpoints": 135,
   "tested endpoints": 19
 }

--- a/resources/coverage/1.1019100.0.json
+++ b/resources/coverage/1.1019100.0.json
@@ -10,75 +10,64 @@
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "create a GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": true,
-      "description": "create a GRPCRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "post",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -88,14 +77,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GatewayClass"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -105,31 +96,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGRPCRoute",
-      "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -139,82 +115,73 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "delete a GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": true,
-      "description": "delete a GRPCRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "delete",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -224,14 +191,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -241,14 +210,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -258,65 +229,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -326,31 +248,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "list",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -359,15 +266,17 @@
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1NamespacedGRPCRoute",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -377,31 +286,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "partially update the specified GatewayClass"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -411,31 +324,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "partially update the specified Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -445,65 +362,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GRPCRoute"
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "patch",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "partially update the specified HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -513,31 +400,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -547,14 +419,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "read the specified GatewayClass"
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019100.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -564,31 +457,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "get",
-      "tested": true,
+      "tested": null,
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -598,31 +495,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified Gateway"
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
     },
     {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": true,
-      "description": "read the specified GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -631,32 +513,17 @@
       "release": "1.1019100.0",
       "version": "v1",
       "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1NamespacedGRPCRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GRPCRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -666,14 +533,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -683,14 +552,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GatewayClass"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -700,14 +571,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified GatewayClass"
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -717,14 +590,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified Gateway"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -734,48 +609,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GRPCRoute"
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -785,14 +628,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -802,847 +647,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified HTTPRoute"
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "post",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "post",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "create a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
-      "conf_tested": null,
-      "description": "delete collection of GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
-      "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "delete a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "delete a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "partially update the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": false,
-      "description": "partially update the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "partially update the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:generic-garbage-collector"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": false,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "read status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "read the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "replace the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.1"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "replace the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
-    },
-    {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1651,15 +665,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendLBPolicy"
+      "description": "create a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1669,14 +685,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1686,14 +704,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a ReferenceGrant"
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1703,14 +723,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TCPRoute"
+      "description": "create a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1720,14 +742,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TLSRoute"
+      "description": "create a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1737,31 +761,92 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create an UDPRoute"
+      "description": "create an UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.1"
+      ],
+      "action": "post",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "create a GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "post",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendTLSPolicy"
+      "description": "create a Gateway",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1770,15 +855,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendLBPolicy",
+      "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendLBPolicy"
+      "description": "delete collection of BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1788,14 +875,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1805,14 +894,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1822,14 +913,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TCPRoute"
+      "description": "delete collection of TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1839,14 +932,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TLSRoute"
+      "description": "delete collection of TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1856,14 +951,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of UDPRoute"
+      "description": "delete collection of UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1872,15 +969,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendLBPolicy"
+      "description": "delete a BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1890,14 +989,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1907,14 +1008,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a ReferenceGrant"
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1924,14 +1027,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TCPRoute"
+      "description": "delete a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1941,14 +1046,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TLSRoute"
+      "description": "delete a TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1958,48 +1065,168 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete an UDPRoute"
+      "description": "delete an UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "deletecollection",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1alpha3CollectionNamespacedBackendTLSPolicy",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendTLSPolicy"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "delete",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendTLSPolicy"
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendlbpolicies",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendtlspolicies",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2008,32 +1235,36 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2BackendLBPolicyForAllNamespaces",
+      "endpoint": "listGatewayNetworkingV1alpha2BackendTLSPolicyForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
       "action": "list",
-      "tested": null,
+      "tested": false,
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
-      "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2042,15 +1273,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2060,14 +1293,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2077,14 +1312,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2094,14 +1331,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2111,14 +1350,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2128,14 +1369,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2145,14 +1388,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2ReferenceGrantForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2162,31 +1407,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
-    },
-    {
-      "kind": "TCPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2196,31 +1426,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
-    },
-    {
-      "kind": "TLSRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019100.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2230,65 +1445,168 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": []
     },
     {
-      "kind": "UDPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        "pilot-discovery/1.23-alpha.ee63c065291a373ea83396b0c60f031da9deb2c9"
+        "pilot-discovery/1.22.1"
       ],
       "action": "list",
       "tested": false,
       "release": "1.1019100.0",
-      "version": "v1alpha2",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.1"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.1"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.1"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
       "action": "list",
       "tested": false,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha3BackendTLSPolicyForAllNamespaces",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019100.0",
-      "version": "v1alpha3",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
-      "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
-    },
-    {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2297,15 +1615,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendLBPolicy"
+      "description": "partially update the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2314,15 +1634,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendLBPolicy"
+      "description": "partially update status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2332,14 +1654,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GRPCRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2349,14 +1692,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2366,14 +1711,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TCPRoute"
+      "description": "partially update the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2383,14 +1730,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TCPRoute"
+      "description": "partially update status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2400,14 +1749,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TLSRoute"
+      "description": "partially update the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2417,14 +1768,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TLSRoute"
+      "description": "partially update status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2434,14 +1787,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified UDPRoute"
+      "description": "partially update the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2451,48 +1806,149 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified UDPRoute"
+      "description": "partially update status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "patch",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "patch",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendTLSPolicy"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "patch",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendTLSPolicy"
+      "description": "partially update the specified Gateway",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2501,15 +1957,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendLBPolicy"
+      "description": "read the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2518,15 +1976,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendLBPolicy"
+      "description": "read status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2536,14 +1996,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GRPCRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2553,14 +2034,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2570,14 +2053,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TCPRoute"
+      "description": "read the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2587,14 +2072,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TCPRoute"
+      "description": "read status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2604,14 +2091,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TLSRoute"
+      "description": "read the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2621,14 +2110,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TLSRoute"
+      "description": "read status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2638,14 +2129,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified UDPRoute"
+      "description": "read the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2655,48 +2148,149 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified UDPRoute"
+      "description": "read status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "get",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "get",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendTLSPolicy"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "get",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendTLSPolicy"
+      "description": "read the specified Gateway",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2705,15 +2299,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendLBPolicy"
+      "description": "replace the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendLBPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
+      "kind": "BackendTLSPolicy",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2722,15 +2318,17 @@
       "release": "1.1019100.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendLBPolicy"
+      "description": "replace status of the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2740,14 +2338,35 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GRPCRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2757,14 +2376,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2774,14 +2395,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TCPRoute"
+      "description": "replace the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2791,14 +2414,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TCPRoute"
+      "description": "replace status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2808,14 +2433,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TLSRoute"
+      "description": "replace the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2825,14 +2452,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TLSRoute"
+      "description": "replace status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2842,14 +2471,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified UDPRoute"
+      "description": "replace the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2859,45 +2490,146 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified UDPRoute"
+      "description": "replace status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "put",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendTLSPolicy"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
-      "kind": "BackendTLSPolicy",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.1"
+      ],
+      "action": "put",
+      "tested": false,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
       "tests": [
         null
       ],
       "action": "put",
       "tested": null,
       "release": "1.1019100.0",
-      "version": "v1alpha3",
+      "version": "v1beta1",
       "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendTLSPolicy"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019100.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     }
   ],
-  "release_date": "2024-07-04T07:18:22",
-  "total endpoints": 154,
-  "tested endpoints": 26
+  "release_date": "2024-07-15T23:52:26",
+  "total endpoints": 135,
+  "tested endpoints": 1
 }

--- a/resources/coverage/1.1019110.0.json
+++ b/resources/coverage/1.1019110.0.json
@@ -10,9 +10,9 @@
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "post",
       "tested": true,
@@ -20,16 +20,20 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "create a GatewayClass"
+      "description": "create a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
@@ -37,33 +41,279 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
       "conf_tested": true,
-      "description": "create a Gateway"
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
       "release": "1.1019110.0",
       "version": "v1",
       "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1NamespacedGRPCRoute",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
       "conf_tested": true,
-      "description": "create a GRPCRoute"
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayObservedGenerationBump::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayObservedGenerationBump",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "GRPCRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        null
+      ],
+      "action": "post",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
       ],
       "action": "post",
       "tested": true,
@@ -71,14 +321,827 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
       "conf_tested": true,
-      "description": "create a HTTPRoute"
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteWeight::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteWeight",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteServiceTypes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteServiceTypes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteExactPathMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHTTPSListener::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHTTPSListener",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -88,14 +1151,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionGatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GatewayClass"
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -105,14 +1170,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of Gateway"
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -122,14 +1189,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -139,16 +1208,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "delete",
       "tested": true,
@@ -156,16 +1227,20 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "delete a GatewayClass"
+      "description": "delete a GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
       ],
       "action": "delete",
       "tested": true,
@@ -173,33 +1248,279 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
       "conf_tested": true,
-      "description": "delete a Gateway"
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
     },
     {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidRouteKind::Gateway"
       ],
       "action": "delete",
       "tested": true,
       "release": "1.1019110.0",
       "version": "v1",
       "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1NamespacedGRPCRoute",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
       "conf_tested": true,
-      "description": "delete a GRPCRoute"
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayObservedGenerationBump::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayObservedGenerationBump",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "GRPCRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
       ],
       "action": "delete",
       "tested": true,
@@ -207,14 +1528,827 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
       "conf_tested": true,
-      "description": "delete a HTTPRoute"
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHTTPSListener::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHTTPSListener",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteExactPathMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteWeight::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteWeight",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteServiceTypes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteServiceTypes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -224,14 +2358,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -241,14 +2377,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -258,14 +2396,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GatewayForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "pilot-discovery/1.22.2"
       ],
@@ -275,14 +2415,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -292,31 +2434,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
-    },
-    {
-      "kind": "GRPCRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1/grpcroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1GRPCRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": []
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -326,16 +2453,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1HTTPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
       ],
       "action": "list",
       "tested": true,
@@ -343,14 +2472,169 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
       "conf_tested": true,
-      "description": "list objects of kind Gateway"
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayObservedGenerationBump::Gateway"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayObservedGenerationBump",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "list",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -360,14 +2644,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -377,16 +2663,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewayClassObservedGenerationBump::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -394,14 +2682,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified GatewayClass"
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -411,16 +2703,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
       ],
       "action": "patch",
       "tested": true,
@@ -428,14 +2722,39 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
       "conf_tested": true,
-      "description": "partially update the specified Gateway"
+      "description": "partially update the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayObservedGenerationBump::Gateway"
+      ],
+      "action": "patch",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayObservedGenerationBump",
+      "conf_tested": true,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -445,14 +2764,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -462,14 +2783,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -479,16 +2802,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified GRPCRoute"
+      "description": "partially update status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
       ],
       "action": "patch",
       "tested": true,
@@ -496,14 +2821,19 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
       "conf_tested": true,
-      "description": "partially update the specified HTTPRoute"
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -513,31 +2843,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
       ],
@@ -547,14 +2862,56 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "read the specified GatewayClass"
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayClassObservedGenerationBump::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1GatewayClass",
+      "suite_test": "GatewayClassObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": [
+        "Gateway"
+      ]
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -564,16 +2921,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
       ],
       "action": "get",
       "tested": true,
@@ -581,14 +2940,1001 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteDisallowedKind",
       "conf_tested": true,
-      "description": "read the specified Gateway"
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHTTPSListener::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteHTTPSListener",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteMethodMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidRouteKind::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidRouteKind",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayInvalidTLSConfiguration::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayInvalidTLSConfiguration",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayObservedGenerationBump::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretMissingReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretMissingReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteWeight::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteWeight",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteServiceTypes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteServiceTypes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedGateway",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -598,31 +3944,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified Gateway"
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        null
       ],
       "action": "get",
-      "tested": true,
+      "tested": null,
       "release": "1.1019110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGRPCRoute",
-      "conf_tested": true,
-      "description": "read the specified GRPCRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -632,16 +3982,18 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedGRPCRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified GRPCRoute"
+      "description": "read status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot.test/unknown"
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMethodMatching::Gateway,HTTPRoute,HTTPRouteMethodMatching"
       ],
       "action": "get",
       "tested": true,
@@ -649,14 +4001,827 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMethodMatching",
       "conf_tested": true,
-      "description": "read the specified HTTPRoute"
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteMethodMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayModifyListeners::Gateway"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayModifyListeners",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteCrossNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteCrossNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteDisallowedKind::Gateway,HTTPRoute,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteDisallowedKind",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteExactPathMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteExactPathMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHeaderMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHeaderMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHostnameIntersection::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHostnameIntersection",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteHTTPSListener::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteHTTPSListener",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidBackendRefUnknownKind::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidBackendRefUnknownKind",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceBackendRef::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceBackendRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidCrossNamespaceParentRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidCrossNamespaceParentRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidNonExistentBackendRef::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidNonExistentBackendRef",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingListenerPort::Gateway,HTTPRoute,HTTPRouteDestinationPortMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingListenerPort",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteDestinationPortMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidParentRefNotMatchingSectionName::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidParentRefNotMatchingSectionName",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteListenerHostnameMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteListenerHostnameMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatchingAcrossRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatchingAcrossRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteMatching::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteObservedGenerationBump::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteObservedGenerationBump",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePathMatchOrder::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRoutePathMatchOrder",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteQueryParamMatching::Gateway,HTTPRoute,HTTPRouteQueryParamMatching"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteQueryParamMatching",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteQueryParamMatching"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectHostAndStatus::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectHostAndStatus",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPath::Gateway,HTTPRoute,HTTPRoutePathRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPath",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectPort::Gateway,HTTPRoute,HTTPRoutePortRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectPort",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePortRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRedirectScheme::Gateway,HTTPRoute,HTTPRouteSchemeRedirect"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRedirectScheme",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteSchemeRedirect"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestHeaderModifier::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMirror::Gateway,HTTPRoute,HTTPRouteRequestMirror"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMirror",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRequestMultipleMirrors::Gateway,HTTPRoute,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRequestMultipleMirrors",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteRequestMirror",
+        "HTTPRouteRequestMultipleMirrors"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteResponseHeaderModifier::Gateway,HTTPRoute,HTTPRouteResponseHeaderModification"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteResponseHeaderModifier",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteResponseHeaderModification"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewriteHost::Gateway,HTTPRoute,HTTPRouteHostRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewriteHost",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRouteHostRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteRewritePath::Gateway,HTTPRoute,HTTPRoutePathRewrite"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteRewritePath",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "HTTPRoutePathRewrite"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteServiceTypes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteServiceTypes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteSimpleSameNamespace::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "standard",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteWeight::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": "HTTPRouteWeight",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -666,14 +4831,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -683,14 +4850,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClass",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GatewayClass"
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "GatewayClass",
       "path": "/apis/gateway.networking.k8s.io/v1/gatewayclasses/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -700,14 +4869,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1GatewayClassStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified GatewayClass"
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -717,14 +4888,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGateway",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified Gateway"
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "Gateway",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/gateways/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -734,14 +4907,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGatewayStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified Gateway"
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -751,31 +4926,35 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/grpcroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
+        null
       ],
       "action": "put",
-      "tested": false,
+      "tested": null,
       "release": "1.1019110.0",
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedGRPCRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GRPCRoute"
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace status of the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -785,14 +4964,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "HTTPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1/namespaces/{namespace}/httproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "stable",
+      "level": "standard",
       "tests": [
         null
       ],
@@ -802,847 +4983,16 @@
       "version": "v1",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1NamespacedHTTPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "post",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "post",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "create a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "create a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "create a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "post",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "create a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
-      "conf_tested": null,
-      "description": "delete collection of GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
-      "conf_tested": null,
-      "description": "delete collection of Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "delete collection of HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "deletecollection",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "delete",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "delete a GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "delete a Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "delete a HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "delete",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "delete a ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "list objects of kind GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "list objects of kind Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "list objects of kind HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "list",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "partially update the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "patch",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": false,
-      "description": "partially update the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "partially update the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "partially update status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "patch",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": false,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": true,
-      "description": "read the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": null,
-      "description": "read status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:generic-garbage-collector"
-      ],
-      "action": "get",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": false,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": true,
-      "description": "read the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": null,
-      "description": "read status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": true,
-      "description": "read the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "get",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": null,
-      "description": "read status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot.test/unknown"
-      ],
-      "action": "get",
-      "tested": true,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": true,
-      "description": "read the specified ReferenceGrant"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
-      "conf_tested": null,
-      "description": "replace the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "GatewayClass",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.22.2"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified GatewayClass"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
-      "conf_tested": null,
-      "description": "replace the specified Gateway"
-    },
-    {
-      "kind": "Gateway",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified Gateway"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
-      "conf_tested": null,
-      "description": "replace the specified HTTPRoute"
-    },
-    {
-      "kind": "HTTPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "put",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
-      "conf_tested": false,
-      "description": "replace status of the specified HTTPRoute"
-    },
-    {
-      "kind": "ReferenceGrant",
-      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
-      "group": "gateway.networking.k8s.io",
-      "level": "beta",
-      "tests": [
-        null
-      ],
-      "action": "put",
-      "tested": null,
-      "release": "1.1019110.0",
-      "version": "v1beta1",
-      "category": "gatewayNetworking",
-      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
-      "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1652,14 +5002,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendLBPolicy"
+      "description": "create a BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1669,14 +5021,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a GRPCRoute"
+      "description": "create a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1686,14 +5040,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a ReferenceGrant"
+      "description": "create a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1703,31 +5059,61 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a TCPRoute"
+      "description": "create a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
       ],
       "action": "post",
-      "tested": null,
+      "tested": true,
       "release": "1.1019110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": null,
-      "description": "create a TLSRoute"
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1737,14 +5123,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create an UDPRoute"
+      "description": "create an UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1754,14 +5142,301 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "createGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "create a BackendTLSPolicy"
+      "description": "create a BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "post",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "create a GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "create a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "post",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "createGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "create a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1771,14 +5446,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendLBPolicy"
+      "description": "delete collection of BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1788,14 +5465,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of GRPCRoute"
+      "description": "delete collection of GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1805,14 +5484,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of ReferenceGrant"
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1822,14 +5503,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TCPRoute"
+      "description": "delete collection of TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1839,14 +5522,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of TLSRoute"
+      "description": "delete collection of TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1856,14 +5541,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2CollectionNamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of UDPRoute"
+      "description": "delete collection of UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1873,14 +5560,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendLBPolicy"
+      "description": "delete a BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1890,14 +5579,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a GRPCRoute"
+      "description": "delete a GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1907,14 +5598,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a ReferenceGrant"
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1924,31 +5617,61 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a TCPRoute"
+      "description": "delete a TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
       ],
       "action": "delete",
-      "tested": null,
+      "tested": true,
       "release": "1.1019110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": null,
-      "description": "delete a TLSRoute"
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1958,14 +5681,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete an UDPRoute"
+      "description": "delete an UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1975,14 +5700,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha3CollectionNamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete collection of BackendTLSPolicy"
+      "description": "delete collection of BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -1992,14 +5719,358 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "deleteGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "delete a BackendTLSPolicy"
+      "description": "delete a BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionGatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "deletecollection",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1CollectionNamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete collection of ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "delete",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "delete a GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "delete a HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "delete",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "deleteGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "delete a ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2009,14 +6080,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2BackendLBPolicyForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendLBPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2026,14 +6099,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2GRPCRouteForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2043,14 +6118,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendLBPolicy"
+      "description": "list objects of kind BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2060,14 +6137,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind GRPCRoute"
+      "description": "list objects of kind GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2077,14 +6156,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2094,14 +6175,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2111,14 +6194,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2128,14 +6213,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/referencegrants",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2145,14 +6232,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2ReferenceGrantForAllNamespaces",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind ReferenceGrant"
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2162,31 +6251,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
-    },
-    {
-      "kind": "TCPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tcproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TCPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind TCPRoute"
+      "description": "list objects of kind TCPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2196,31 +6270,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
-    },
-    {
-      "kind": "TLSRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/tlsroutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2TLSRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind TLSRoute"
+      "description": "list objects of kind TLSRoute",
+      "suite_test_features": []
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2230,31 +6289,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
-    },
-    {
-      "kind": "UDPRoute",
-      "path": "/apis/gateway.networking.k8s.io/v1alpha2/udproutes",
-      "group": "gateway.networking.k8s.io",
-      "level": "alpha",
-      "tests": [
-        "pilot-discovery/1.23-alpha.23fc23c669d0567a029e77fa0fa9ee5dcee094ac"
-      ],
-      "action": "list",
-      "tested": false,
-      "release": "1.1019110.0",
-      "version": "v1alpha2",
-      "category": "gatewayNetworking",
-      "endpoint": "listGatewayNetworkingV1alpha2UDPRouteForAllNamespaces",
-      "conf_tested": false,
-      "description": "list objects of kind UDPRoute"
+      "description": "list objects of kind UDPRoute",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
       ],
@@ -2264,14 +6308,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha3BackendTLSPolicyForAllNamespaces",
+      "suite_test": "",
       "conf_tested": false,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": []
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2281,14 +6327,168 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "listGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "list objects of kind BackendTLSPolicy"
+      "description": "list objects of kind BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1GatewayForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1HTTPRouteForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "list",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/metadata-informers"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/referencegrants",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "list",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "listGatewayNetworkingV1beta1ReferenceGrantForAllNamespaces",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "list objects of kind ReferenceGrant",
+      "suite_test_features": []
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2298,14 +6498,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendLBPolicy"
+      "description": "partially update the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2315,14 +6517,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendLBPolicy"
+      "description": "partially update status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2332,14 +6536,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified GRPCRoute"
+      "description": "partially update the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2349,14 +6555,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified ReferenceGrant"
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2366,14 +6574,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TCPRoute"
+      "description": "partially update the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2383,14 +6593,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TCPRoute"
+      "description": "partially update status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2400,14 +6612,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified TLSRoute"
+      "description": "partially update the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2417,14 +6631,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified TLSRoute"
+      "description": "partially update status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2434,14 +6650,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified UDPRoute"
+      "description": "partially update the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2451,14 +6669,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified UDPRoute"
+      "description": "partially update status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2468,14 +6688,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update the specified BackendTLSPolicy"
+      "description": "partially update the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2485,14 +6707,149 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "patchGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "partially update status of the specified BackendTLSPolicy"
+      "description": "partially update status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "patch",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "partially update the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "patch",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "partially update the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "patch",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "patchGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "partially update the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2502,14 +6859,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendLBPolicy"
+      "description": "read the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2519,14 +6878,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendLBPolicy"
+      "description": "read status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2536,14 +6897,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified GRPCRoute"
+      "description": "read the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2553,14 +6916,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified ReferenceGrant"
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2570,14 +6935,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified TCPRoute"
+      "description": "read the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2587,31 +6954,61 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TCPRoute"
+      "description": "read status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
-        null
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
       ],
       "action": "get",
-      "tested": null,
+      "tested": true,
       "release": "1.1019110.0",
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
-      "conf_tested": null,
-      "description": "read the specified TLSRoute"
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "TLSRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1alpha2",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified TLSRoute",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2621,14 +7018,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified TLSRoute"
+      "description": "read status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2638,14 +7037,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified UDPRoute"
+      "description": "read the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2655,14 +7056,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified UDPRoute"
+      "description": "read status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2672,14 +7075,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read the specified BackendTLSPolicy"
+      "description": "read the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2689,14 +7094,377 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "readGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "read status of the specified BackendTLSPolicy"
+      "description": "read status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kubectl/v1.30.2 (linux/amd64) kubernetes/3968350"
+      ],
+      "action": "get",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "read the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "kube-controller-manager/v1.30.0 (linux/amd64) kubernetes/7c48c2b/system:serviceaccount:kube-system:generic-garbage-collector"
+      ],
+      "action": "get",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "read the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteSimpleSameNamespace::Gateway,TLSRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteSimpleSameNamespace",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.0.0::::"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": "",
+      "conf_tested": true,
+      "description": "read the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewayWithAttachedRoutes::Gateway,HTTPRoute"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": "GatewayWithAttachedRoutes",
+      "conf_tested": true,
+      "description": "read the specified HTTPRoute",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute"
+      ]
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "get",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "read status of the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantSpecific::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantSpecific",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::TLSRouteInvalidReferenceGrant::Gateway,TLSRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "TLSRouteInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "TLSRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretInvalidReferenceGrant::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::GatewaySecretReferenceGrantAllInNamespace::Gateway,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "GatewaySecretReferenceGrantAllInNamespace",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRouteReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRouteReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "gateway-api-conformance.test::v1.1.0::HTTPRoutePartiallyInvalidViaInvalidReferenceGrant::Gateway,HTTPRoute,ReferenceGrant"
+      ],
+      "action": "get",
+      "tested": true,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "readGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": "HTTPRoutePartiallyInvalidViaInvalidReferenceGrant",
+      "conf_tested": true,
+      "description": "read the specified ReferenceGrant",
+      "suite_test_features": [
+        "Gateway",
+        "HTTPRoute",
+        "ReferenceGrant"
+      ]
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2706,14 +7474,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendLBPolicy"
+      "description": "replace the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendLBPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/backendlbpolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2723,14 +7493,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedBackendLBPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendLBPolicy"
+      "description": "replace status of the specified BackendLBPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "GRPCRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/grpcroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2740,14 +7512,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedGRPCRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified GRPCRoute"
+      "description": "replace the specified GRPCRoute",
+      "suite_test_features": null
     },
     {
       "kind": "ReferenceGrant",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/referencegrants/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2757,14 +7531,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedReferenceGrant",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified ReferenceGrant"
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2774,14 +7550,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TCPRoute"
+      "description": "replace the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TCPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tcproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2791,14 +7569,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTCPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TCPRoute"
+      "description": "replace status of the specified TCPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2808,14 +7588,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified TLSRoute"
+      "description": "replace the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "TLSRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/tlsroutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2825,14 +7607,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedTLSRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified TLSRoute"
+      "description": "replace status of the specified TLSRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2842,14 +7626,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRoute",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified UDPRoute"
+      "description": "replace the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "UDPRoute",
       "path": "/apis/gateway.networking.k8s.io/v1alpha2/namespaces/{namespace}/udproutes/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2859,14 +7645,16 @@
       "version": "v1alpha2",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha2NamespacedUDPRouteStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified UDPRoute"
+      "description": "replace status of the specified UDPRoute",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2876,14 +7664,16 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicy",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace the specified BackendTLSPolicy"
+      "description": "replace the specified BackendTLSPolicy",
+      "suite_test_features": null
     },
     {
       "kind": "BackendTLSPolicy",
       "path": "/apis/gateway.networking.k8s.io/v1alpha3/namespaces/{namespace}/backendtlspolicies/{name}/status",
       "group": "gateway.networking.k8s.io",
-      "level": "alpha",
+      "level": "experimental",
       "tests": [
         null
       ],
@@ -2893,11 +7683,146 @@
       "version": "v1alpha3",
       "category": "gatewayNetworking",
       "endpoint": "replaceGatewayNetworkingV1alpha3NamespacedBackendTLSPolicyStatus",
+      "suite_test": null,
       "conf_tested": null,
-      "description": "replace status of the specified BackendTLSPolicy"
+      "description": "replace status of the specified BackendTLSPolicy",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClass",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified GatewayClass",
+      "suite_test_features": null
+    },
+    {
+      "kind": "GatewayClass",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/gatewayclasses/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "put",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1GatewayClassStatus",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "replace status of the specified GatewayClass",
+      "suite_test_features": []
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGateway",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified Gateway",
+      "suite_test_features": null
+    },
+    {
+      "kind": "Gateway",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/gateways/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "put",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedGatewayStatus",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "replace status of the specified Gateway",
+      "suite_test_features": []
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRoute",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified HTTPRoute",
+      "suite_test_features": null
+    },
+    {
+      "kind": "HTTPRoute",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/httproutes/{name}/status",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        "pilot-discovery/1.22.2"
+      ],
+      "action": "put",
+      "tested": false,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedHTTPRouteStatus",
+      "suite_test": "",
+      "conf_tested": false,
+      "description": "replace status of the specified HTTPRoute",
+      "suite_test_features": []
+    },
+    {
+      "kind": "ReferenceGrant",
+      "path": "/apis/gateway.networking.k8s.io/v1beta1/namespaces/{namespace}/referencegrants/{name}",
+      "group": "gateway.networking.k8s.io",
+      "level": "experimental",
+      "tests": [
+        null
+      ],
+      "action": "put",
+      "tested": null,
+      "release": "1.1019110.0",
+      "version": "v1beta1",
+      "category": "gatewayNetworking",
+      "endpoint": "replaceGatewayNetworkingV1beta1NamespacedReferenceGrant",
+      "suite_test": null,
+      "conf_tested": null,
+      "description": "replace the specified ReferenceGrant",
+      "suite_test_features": null
     }
   ],
-  "release_date": "2024-07-08T03:45:37",
+  "release_date": "2024-07-15T23:58:33",
   "total endpoints": 154,
-  "tested endpoints": 26
+  "tested endpoints": 25
 }


### PR DESCRIPTION
Use latest results.
Results now include test name and features as `suite_test` and `suite_test_features`, respectively.
Discard if results are invalid.